### PR TITLE
Update addon via `ember init`

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -10,6 +10,5 @@ dist/
 .npmignore
 **/.gitkeep
 bower.json
-ember-cli-build.js
 Brocfile.js
 testem.json

--- a/.watchmanconfig
+++ b/.watchmanconfig
@@ -1,3 +1,3 @@
 {
-  "ignore_dirs": ["tmp"]
+  "ignore_dirs": ["tmp", "dist"]
 }

--- a/bower.json
+++ b/bower.json
@@ -1,15 +1,17 @@
 {
   "name": "ember-redirect",
   "dependencies": {
-    "ember": "1.13.3",
-    "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
-    "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",
-    "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.5",
-    "ember-qunit": "0.4.1",
-    "ember-qunit-notifications": "0.0.7",
-    "ember-resolver": "~0.1.18",
-    "jquery": "^1.11.1",
-    "loader.js": "ember-cli/loader.js#3.2.0",
-    "qunit": "~1.17.1"
+    "ember": "components/ember#release",
+    "ember-cli-shims": "0.0.6",
+    "ember-cli-test-loader": "0.2.1",
+    "ember-load-initializers": "0.1.7",
+    "ember-qunit": "0.4.11",
+    "ember-qunit-notifications": "0.1.0",
+    "jquery": "^1.11.3",
+    "loader.js": "3.3.0",
+    "qunit": "~1.19.0"
+  },
+  "resolutions": {
+    "ember": "release"
   }
 }

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -1,8 +1,8 @@
 /* global require, module */
-var EmberApp = require('ember-cli/lib/broccoli/ember-addon');
+var EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 
 module.exports = function(defaults) {
-  var app = new EmberApp(defaults, {
+  var app = new EmberAddon(defaults, {
     // Add options here
   });
 

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "test": "tests"
   },
   "scripts": {
-    "start": "ember server",
     "build": "ember build",
+    "start": "ember server",
     "test": "ember try:testall"
   },
   "repository": "https://github.com/thoov/ember-redirect",
@@ -18,22 +18,24 @@
   "author": "Travis Hoover <thoov7@gmail.com>",
   "license": "MIT",
   "devDependencies": {
-    "broccoli-asset-rev": "^2.0.2",
-    "ember-cli": "1.13.1",
-    "ember-cli-app-version": "0.4.0",
+    "broccoli-asset-rev": "^2.2.0",
+    "ember-ajax": "0.6.2",
+    "ember-cli": "1.13.8",
+    "ember-cli-app-version": "^1.0.0",
     "ember-cli-content-security-policy": "0.4.0",
-    "ember-cli-dependency-checker": "^1.0.0",
-    "ember-cli-htmlbars": "0.7.9",
-    "ember-cli-htmlbars-inline-precompile": "^0.1.1",
-    "ember-cli-ic-ajax": "0.2.1",
-    "ember-cli-inject-live-reload": "^1.3.0",
-    "ember-cli-qunit": "0.3.15",
-    "ember-cli-release": "0.2.3",
-    "ember-cli-uglify": "^1.0.1",
-    "ember-disable-proxy-controllers": "^1.0.0",
-    "ember-export-application-global": "^1.0.2",
+    "ember-cli-dependency-checker": "^1.1.0",
+    "ember-cli-github-pages": "0.0.6",
+    "ember-cli-htmlbars": "^1.0.0",
+    "ember-cli-htmlbars-inline-precompile": "^0.3.1",
+    "ember-cli-inject-live-reload": "^1.3.1",
+    "ember-cli-qunit": "^1.0.3",
+    "ember-cli-release": "0.2.7",
+    "ember-cli-uglify": "^1.2.0",
     "ember-disable-prototype-extensions": "^1.0.0",
-    "ember-try": "0.0.6"
+    "ember-disable-proxy-controllers": "^1.0.1",
+    "ember-export-application-global": "^1.0.4",
+    "ember-resolver": "^2.0.3",
+    "ember-try": "~0.0.8"
   },
   "keywords": [
     "ember-addon",
@@ -43,7 +45,7 @@
     "redirect"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.0.0"
+    "ember-cli-babel": "^5.1.5"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/tests/dummy/app/app.js
+++ b/tests/dummy/app/app.js
@@ -1,16 +1,16 @@
 import Ember from 'ember';
-import Resolver from 'ember/resolver';
+import Resolver from 'ember-resolver';
 import loadInitializers from 'ember/load-initializers';
 import config from './config/environment';
 
-var App;
+let App;
 
 Ember.MODEL_FACTORY_INJECTIONS = true;
 
 App = Ember.Application.extend({
   modulePrefix: config.modulePrefix,
   podModulePrefix: config.podModulePrefix,
-  Resolver: Resolver
+  Resolver
 });
 
 loadInitializers(App, config.modulePrefix);

--- a/tests/dummy/app/index.html
+++ b/tests/dummy/app/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <title>Dummy</title>
+    <title>Ember-Redirect Demo</title>
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 

--- a/tests/dummy/app/styles/app.css
+++ b/tests/dummy/app/styles/app.css
@@ -1,3 +1,20 @@
 html, body {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
   margin: 20px;
+}
+
+#title,
+p {
+  text-align: center;
+}
+
+.header {
+  align-items: center;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  justify-content: center;
+  max-width: 600px;
 }

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,3 +1,15 @@
-<h2 id="title">Welcome to Ember.js</h2>
+<h2 id="title"><a href="https://github.com/thoov/ember-redirect" target="_blank">Ember-Redirect Demo</a></h2>
+
+<div class="header">
+  {{#link-to 'index'}}<button>Home</button>{{/link-to}}
+  {{#link-to 'sample'}}<button>sample -> something</button>{{/link-to}}
+  {{#link-to 'testing.index'}}<button>testing/index -> something</button>{{/link-to}}
+  {{#link-to 'testing.foo'}}<button>testing/foo -> bar</button>{{/link-to}}
+  {{#link-to 'bar.cat'}}<button>bar/cat -> testing/foo -> bar</button>{{/link-to}}
+  {{#link-to 'bar.world'}}<button>bar/world -> testing/hello</button>{{/link-to}}
+  {{#link-to 'account' 1 2}}<button>account/1/other/2 -> user/1/something/2</button>{{/link-to}}
+  {{#link-to 'profile' 3 4}}<button>profile/3/user/4 -> user/4/something/3</button>{{/link-to}}
+  {{#link-to 'login'}}<button>login -> foo</button>{{/link-to}}
+</div>
 
 {{outlet}}

--- a/tests/dummy/app/templates/bar.hbs
+++ b/tests/dummy/app/templates/bar.hbs
@@ -1,0 +1,2 @@
+<p>Before I leave, brush my teeth with a bottle of Jack</p>
+<p>'Cause when I leave for the night, I ain't coming back</p>

--- a/tests/dummy/app/templates/foo.hbs
+++ b/tests/dummy/app/templates/foo.hbs
@@ -1,0 +1,1 @@
+<p>Bunny Foo-Foo</p>

--- a/tests/dummy/app/templates/something.hbs
+++ b/tests/dummy/app/templates/something.hbs
@@ -1,0 +1,1 @@
+<p>Say something, I'm giving up on you.</p>

--- a/tests/dummy/app/templates/testing/hello.hbs
+++ b/tests/dummy/app/templates/testing/hello.hbs
@@ -1,0 +1,1 @@
+<iframe width="560" height="315" src="https://www.youtube.com/embed/0_I0DBUA_GI" frameborder="0" allowfullscreen></iframe>

--- a/tests/dummy/app/templates/user.hbs
+++ b/tests/dummy/app/templates/user.hbs
@@ -1,0 +1,2 @@
+<p>Well, use me, use me</p>
+<p>'Cause you ain't that average groupie</p>

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -40,7 +40,7 @@ module.exports = function(environment) {
   }
 
   if (environment === 'production') {
-
+    ENV.baseURL = '/ember-redirect';
   }
 
   return ENV;

--- a/tests/helpers/destroy-app.js
+++ b/tests/helpers/destroy-app.js
@@ -1,0 +1,5 @@
+import Ember from 'ember';
+
+export default function destroyApp(application) {
+  Ember.run(application, 'destroy');
+}

--- a/tests/helpers/resolver.js
+++ b/tests/helpers/resolver.js
@@ -1,7 +1,7 @@
-import Resolver from 'ember/resolver';
+import Resolver from 'ember-resolver';
 import config from '../../config/environment';
 
-var resolver = Resolver.create();
+const resolver = Resolver.create();
 
 resolver.namespace = {
   modulePrefix: config.modulePrefix,

--- a/tests/helpers/start-app.js
+++ b/tests/helpers/start-app.js
@@ -3,12 +3,12 @@ import Application from '../../app';
 import config from '../../config/environment';
 
 export default function startApp(attrs) {
-  var application;
+  let application;
 
-  var attributes = Ember.merge({}, config.APP);
+  let attributes = Ember.merge({}, config.APP);
   attributes = Ember.merge(attributes, attrs); // use defaults, but you can override;
 
-  Ember.run(function() {
+  Ember.run(() => {
     application = Application.create(attributes);
     application.setupForTesting();
     application.injectTestHelpers();

--- a/tests/index.html
+++ b/tests/index.html
@@ -24,7 +24,7 @@
     <script src="assets/vendor.js"></script>
     <script src="assets/test-support.js"></script>
     <script src="assets/dummy.js"></script>
-    <script src="testem.js"></script>
+    <script src="testem.js" integrity=""></script>
     <script src="assets/test-loader.js"></script>
 
     {{content-for 'body-footer'}}


### PR DESCRIPTION
Make demo app more interactive and integrate ember-cli-github-pages (See [Instructions](emberup.co/host-addon-examples-through-github-pages/))

The generated route in the demo app seems to be having issues, so I removed the `link-to` I was going to add for it.  I believe this is an existing issue, so will log it separately.