### PR TITLE
Version bump 5.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-redirect",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "description": "EmberJS redirect addon for Ember-CLI.",
   "keywords": [
     "ember-addon",


### PR DESCRIPTION
This version includes 'external-redirect-support' #22

@thoov Can we score a NPM publish of this version?