### PR TITLE
Move ember-window-mock to deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   },
   "dependencies": {
     "bower": "^1.8.0",
-    "ember-cli-babel": "^6.3.0"
+    "ember-cli-babel": "^6.3.0",
+    "ember-window-mock": "0.1.4"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",
@@ -43,7 +44,6 @@
     "ember-load-initializers": "^1.0.0",
     "ember-resolver": "^4.0.0",
     "ember-source": "~2.15.0",
-    "ember-window-mock": "0.1.4",
     "loader.js": "^4.2.3"
   },
   "engines": {


### PR DESCRIPTION
This needs to be a dep, not devDep, so the consumer has access to it.